### PR TITLE
fix: Clean up README links and titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Run Hacktoberfest 2025 Contributions on TestMu AI (Formerly LambdaTest)
+﻿# LambdaTest Hacktoberfest 2025 on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -17,9 +17,9 @@ With TestMu AI (Formerly LambdaTest), you can run open-source contributions and 
 
 ### Prerequisites
 
-1. Register for [Hacktoberfest 2025](https://hacktoberfest.com).
+1. Register for Hacktoberfest 2025.
 2. A GitHub account for forking repositories and submitting pull requests.
-3. A TestMu AI account — [sign up here](https://www.testmuai.com/register/).
+3. A TestMu AI account — sign up here.
 4. Development tools relevant to the project you are contributing to (Node.js, Java, Python, etc.).
 
 ### Setup
@@ -31,8 +31,8 @@ git clone https://github.com/LambdaTest/lambdatest-hacktoberfest-2025
 cd lambdatest-hacktoberfest-2025
 ```
 
-1. Fork one of the [supporting projects](https://github.com/LambdaTest/lambdatest-hacktoberfest-2025#-projects-you-can-contribute-to) and start contributing.
-2. Install the [LambdaTest Cloud GitHub App](https://github.com/apps/lambdatest-ai-cloud) on your forked repository.
+1. Fork one of the supporting projects and start contributing.
+2. Install the LambdaTest Cloud GitHub App on your forked repository.
 3. Set your TestMu AI credentials:
 
 - For Linux/macOS:
@@ -58,10 +58,10 @@ set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 
 **Projects you can contribute to:**
 
-- **[LambdaTest/testcafe-browser-provider-lambdatest](https://github.com/LambdaTest/testcafe-browser-provider-lambdatest)**: NPM Plugin For TestCafe Integration With LambdaTest.
-- **[LambdaTest/lambdatest-gradle-plugin](https://github.com/LambdaTest/lambdatest-gradle-plugin)**: Source code for LambdaTest's Espresso Gradle plugin.
-- **[LambdaTest/lambdatest-buildkite-plugin](https://github.com/LambdaTest/lambdatest-buildkite-plugin)**: Buildkite plugin that opens a LambdaTest tunnel.
-- **[LambdaTest/wdio-lambdatest-service](https://github.com/LambdaTest/wdio-lambdatest-service)**: WebdriverIO LambdaTest Service.
+- **LambdaTest/testcafe-browser-provider-lambdatest**: NPM Plugin For TestCafe Integration With LambdaTest.
+- **LambdaTest/lambdatest-gradle-plugin**: Source code for LambdaTest's Espresso Gradle plugin.
+- **LambdaTest/lambdatest-buildkite-plugin**: Buildkite plugin that opens a LambdaTest tunnel.
+- **LambdaTest/wdio-lambdatest-service**: WebdriverIO LambdaTest Service.
 
 **Event Duration**: October 1 – October 31, 2025.
 


### PR DESCRIPTION
Removes non-template hyperlinks from Prerequisites, Setup, and Run tests sections. Fixes H1 title where needed.